### PR TITLE
3.9: Configurable loading screen tick interval

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.16.1
 yarn_mappings=1.16.1+build.21
 loader_version=0.13.3
 # Mod Properties
-mod_version=3.8
+mod_version=3.9
 maven_group=com.redlimerl
 archives_base_name=sleepbackground
 

--- a/src/main/java/com/redlimerl/sleepbackground/config/ConfigValues.java
+++ b/src/main/java/com/redlimerl/sleepbackground/config/ConfigValues.java
@@ -37,6 +37,10 @@ public class ConfigValues {
             new LogIntervalConfigValue(500, "Changes how often the game prints the worldgen progress to the log file, may be useful for macros (minimum: 50ms, max/default: 500ms)");
 
 
+    public static final LoadingTickConfigValue LOADING_TICK_INTERVAL =
+            new LoadingTickConfigValue(1, "Changes how often the game ticks on the loading screen/preview, decreasing this number will reduce reset input latency (minimum/default: 1ms, max (vanilla): 16ms)");
+
+
     static {
         ALL_CONFIGS.add(BACKGROUND_FRAME_RATE);
         ALL_CONFIGS.add(LOADING_SCREEN_FRAME_RATE);
@@ -44,5 +48,6 @@ public class ConfigValues {
         ALL_CONFIGS.add(WORLD_INITIAL_FRAME_RATE);
         ALL_CONFIGS.add(NONE_PLAYING_FRAME_RATE);
         ALL_CONFIGS.add(LOG_INTERVAL);
+        ALL_CONFIGS.add(LOADING_TICK_INTERVAL);
     }
 }

--- a/src/main/java/com/redlimerl/sleepbackground/config/LoadingTickConfigValue.java
+++ b/src/main/java/com/redlimerl/sleepbackground/config/LoadingTickConfigValue.java
@@ -1,0 +1,30 @@
+package com.redlimerl.sleepbackground.config;
+
+import com.google.gson.JsonObject;
+
+public class LoadingTickConfigValue extends ConfigValue {
+
+    private int tickInterval;
+
+    public LoadingTickConfigValue(int defaultLimit, String comment) {
+        super("loading_screen_tick_interval", comment);
+        this.tickInterval = defaultLimit;
+    }
+
+    @Override
+    public void loadToInit(JsonObject configObject) {
+        if (configObject.has(this.getKeyName())) {
+            this.tickInterval = configObject.get(this.getKeyName()).getAsInt();
+            if (this.tickInterval < 1 || this.tickInterval > 16) throw new IllegalArgumentException("Loading screen tick interval must be >= 1ms and <= 16ms");
+        }
+    }
+
+    @Override
+    public void writeToJson(JsonObject configObject) {
+        configObject.addProperty(this.getKeyName(), this.tickInterval);
+    }
+
+    public int getTickInterval() {
+        return this.isEnable() ? tickInterval : 16;
+    }
+}

--- a/src/main/java/com/redlimerl/sleepbackground/mixin/MixinMinecraftClient.java
+++ b/src/main/java/com/redlimerl/sleepbackground/mixin/MixinMinecraftClient.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MinecraftClient.class)
@@ -33,5 +34,10 @@ public class MixinMinecraftClient {
     @Inject(method = "drawProfilerResults", at = @At("HEAD"), cancellable = true, expect = 0, require = 0)
     private void onDraw(CallbackInfo ci) {
         if (SleepBackground.LATEST_LOCK_FRAME) ci.cancel();
+    }
+
+    @ModifyArg(method = "startIntegratedServer(Ljava/lang/String;Lnet/minecraft/util/registry/RegistryTracker$Modifiable;Ljava/util/function/Function;Lcom/mojang/datafixers/util/Function4;ZLnet/minecraft/client/MinecraftClient$WorldLoadAction;)V", at = @At(value = "INVOKE", target = "Ljava/lang/Thread;sleep(J)V"))
+    public long onSleep(long l){
+        return ConfigValues.LOADING_TICK_INTERVAL.getTickInterval();
     }
 }


### PR DESCRIPTION
During the loading screen/world preview, the game has a ticking/rendering loop with a Thread.sleep(16L) in it. GLFW events, such as mouse and keyboard inputs, are only polled once every frame. This results in additional latency for resetting, where the game can wait for up to 30ms before processing the reset input. 

Reducing the Thread.sleep() duration down to 1ms results in less reset latency and not causing much additional overhead, providing roughly a **8-10% resetting performance improvement on both a 16 instance wall and laptop single instance.** 

Tick interval settings were tested across various PCs to confirm 1ms as a good default value — higher numbers like 16ms always produced worse results, with 1ms and 2ms nearly tying best performance (1ms winning in most cases)

This change only affects 1 line of Minecraft code, and does not allow the value to be changed to be slower than the default.