### PR TITLE
fix crash on 1.20.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ jar {
     from("LICENSE") {
         rename { "${it}_${project.archivesBaseName}" }
     }
-    project.version = project.version + "-1.20-1.21"
+    project.version = project.version + "-1.20-1.21.1"
 }
 
 // configure the maven publication

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.20.4
 yarn_mappings=1.20.4+build.3
 loader_version=0.15.6
 # Mod Properties
-mod_version=3.9.1
+mod_version=3.9.2
 maven_group=com.redlimerl
 archives_base_name=sleepbackground
 

--- a/src/main/java/com/redlimerl/sleepbackground/mixin/MixinGameRenderer.java
+++ b/src/main/java/com/redlimerl/sleepbackground/mixin/MixinGameRenderer.java
@@ -10,8 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(GameRenderer.class)
 public class MixinGameRenderer {
     @Dynamic
-    // class_9779 -> RenderTickCounter
-    @Inject(method = {"render", "Lnet/minecraft/class_757;method_3192(Lnet/minecraft/class_9779;Z)V"}, at = @At("HEAD"), require = 1, cancellable = true)
+    @Inject(method = "method_3192", at = @At("HEAD"), cancellable = true, remap = false)
     private void onRender(CallbackInfo callbackInfo) {
         if (SleepBackground.LATEST_LOCK_FRAME) {
             callbackInfo.cancel();

--- a/src/main/java/com/redlimerl/sleepbackground/mixin/MixinMinecraftClient.java
+++ b/src/main/java/com/redlimerl/sleepbackground/mixin/MixinMinecraftClient.java
@@ -5,8 +5,7 @@ import com.redlimerl.sleepbackground.config.ConfigValues;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.world.ClientWorld;
 import org.jetbrains.annotations.Nullable;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
@@ -36,7 +35,8 @@ public class MixinMinecraftClient {
         if (SleepBackground.LATEST_LOCK_FRAME) ci.cancel();
     }
 
-    @ModifyArg(method = "startIntegratedServer", at = @At(value = "INVOKE", target = "Ljava/lang/Thread;sleep(J)V"))
+    @Dynamic
+    @ModifyArg(method = "method_29610", at = @At(value = "INVOKE", target = "Ljava/lang/Thread;sleep(J)V"), remap = false)
     public long onSleep(long l){
         return ConfigValues.LOADING_TICK_INTERVAL.getTickInterval();
     }


### PR DESCRIPTION
we can ignore descriptors on MinecraftServer#startIntegratedServer, as the intermediary name is matched correctly between all the target versions. the same technique can be used on GameRenderer#render.